### PR TITLE
Add unit tests to make sure parentheses are included in expressions

### DIFF
--- a/tests/AllTest.php
+++ b/tests/AllTest.php
@@ -269,4 +269,14 @@ class AllTest extends TestCase
         $q = $parser->parse("SELECT * FROM users INNER JOIN lol ON x = y");
         $this->assertEquals(['users', 'lol'], $q[0]->getAllTables());
     }
+
+    public function testRewriteQueryParentheses()
+    {
+        Writer::setInstance('mysql');
+        $parser = new SQLParser;
+        $queries = $parser->parse("SELECT * FROM db.stable WHERE (foo = :foo AND bar = :bar) OR xxx = :xxx");
+        $sql = "SELECT * FROM `db`.`stable` WHERE (`foo` = :foo AND `bar` = :bar) OR `xxx` = :xxx";
+
+        $this->assertEquals($sql, (string)$queries[0]);
+    }
 }


### PR DESCRIPTION
Fixes on the issues reported in #2 